### PR TITLE
feat: Establish initial PTA documentation structure

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Parent Teacher Association - Code of Conduct
+
+## Our Pledge
+
+We, the members, leaders, and participants of the [School Name] Parent Teacher Association (PTA), pledge to make participation in our group and community a harassment-free and inclusive experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+*   Demonstrating empathy and kindness toward other people
+*   Being respectful of differing opinions, viewpoints, and experiences
+*   Giving and gracefully accepting constructive feedback
+*   Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+*   Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+*   The use of sexualized language or imagery, and sexual attention or advances of any kind
+*   Trolling, insulting or derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or email address, without their explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional or community setting
+
+## Enforcement Responsibilities
+
+PTA leaders (e.g., committee chairs, officers) are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+PTA leaders have the right and responsibility to remove, edit, or reject comments, communications, or other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all PTA events, activities, and digital spaces (e.g., online forums, social media, this repository), and it also applies when an individual is officially representing the PTA in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Reporting Violations
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the PTA leadership by contacting [PTA Contact Email or Person for Reporting]. All complaints will be reviewed and investigated promptly and fairly.
+
+All PTA leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+PTA leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1.  **Correction:**
+    *   **Community Impact:** Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+    *   **Consequence:** A private, written warning from PTA leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2.  **Warning:**
+    *   **Community Impact:** A violation through a single incident or series of actions.
+    *   **Consequence:** A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+3.  **Temporary Ban:**
+    *   **Community Impact:** A serious violation of community standards, including sustained inappropriate behavior.
+    *   **Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+4.  **Permanent Ban:**
+    *   **Community Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+    *   **Consequence:** A permanent ban from any sort of public interaction within the PTA community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -1,0 +1,48 @@
+# PTA Processes
+
+This document outlines some of the key processes for the [School Name] Parent Teacher Association (PTA). Our aim is to make participation clear and straightforward.
+
+## Joining the PTA
+
+We welcome all parents, guardians, and teachers of [School Name] to join the PTA.
+
+*   **Membership Form:** Please fill out the online membership form available at [Link to Membership Form] or request a physical form from [PTA Contact/Office].
+*   **Membership Dues:** There is a nominal annual membership fee of [Amount] to help support PTA activities. This can be paid [Payment Methods, e.g., online, at the school office].
+*   **Stay Informed:** Once a member, you'll be added to our mailing list to receive updates on meetings, events, and volunteer opportunities.
+
+## Proposing Initiatives or Activities
+
+We encourage members to bring forward new ideas for PTA initiatives, events, or activities that can benefit our school community.
+
+*   **Initial Discussion:** You can discuss your idea informally with a PTA committee member or officer, or bring it up during the 'New Business' section of a PTA meeting.
+*   **Formal Proposal (if needed):** For larger initiatives, you may be asked to submit a brief written proposal outlining:
+    *   The objective of the initiative.
+    *   Potential benefits to the students/school community.
+    *   Estimated resources required (e.g., volunteers, budget).
+    *   Your contact information.
+*   **Review Process:** Proposals will be reviewed by the relevant PTA committee or the executive board. You will be contacted regarding the status of your proposal.
+
+## Decision-Making Process (Overview)
+
+*   **Meetings:** Most decisions are discussed and voted upon during regular PTA meetings. Meeting schedules and agendas are circulated in advance.
+*   **Quorum:** A minimum number of members (as defined in the PTA Charter) must be present for a vote to be valid.
+*   **Voting:** Decisions are typically made by a simple majority vote of members present, unless otherwise specified in the Charter (e.g., for amendments to the charter or election of officers).
+*   **Committees:** The PTA has several committees (e.g., Events, Fundraising, Communications) that may make recommendations or decisions within their specific areas of responsibility, as delegated by the executive board or general membership.
+
+## Volunteering
+
+Our PTA thrives on the support of volunteers!
+
+*   **Opportunities:** Look out for announcements regarding volunteer needs for specific events or ongoing activities.
+*   **Sign-up:** Sign-up sheets or online forms will be made available for volunteer registration.
+*   **Contact:** You can also express your general interest in volunteering by contacting [PTA Volunteer Coordinator Email/Person].
+
+## Amendments to this Document
+
+This document can be updated as needed by a resolution at a PTA general meeting.
+
+---
+
+For more detailed information on governance, please refer to the [PTA Charter](./legal/PTA_CHARTER.md).
+
+If you have any questions about these processes, please contact [PTA Contact Email or Person].

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# Invictus-dempsey
+# Welcome to the [School Name] Parent Teacher Association Repository
+
+This repository serves as a central hub for all documentation related to the [School Name] Parent Teacher Association (PTA). Our PTA is dedicated to fostering a strong community and enriching the educational experience for all our students.
+
+We believe in transparency and collaboration, and this space is designed to provide easy access to important information for all members and interested parties.
+
+## Key Documents
+
+*   **[Code of Conduct](./CODE_OF_CONDUCT.md):** Outlines the expected standards of behavior for all PTA members and participants in PTA activities. We are committed to maintaining a respectful and inclusive environment.
+*   **[PTA Processes](./PROCESSES.md):** Provides information on how the PTA operates, including:
+    *   How to become a member.
+    *   How to propose new initiatives or activities.
+    *   An overview of our decision-making processes.
+*   **[Legal and Corporate Documents](./legal/):** Contains official documents such as the PTA charter and other relevant legal filings.
+
+## Getting Involved
+
+We encourage all parents and teachers to get involved with the PTA. Your participation is vital to our success! Please refer to the [PTA Processes](./PROCESSES.md) document for more information on how you can contribute.
+
+## Questions?
+
+If you have any questions, please don't hesitate to reach out to [PTA Contact Email or Person].

--- a/legal/LICENSE.md
+++ b/legal/LICENSE.md
@@ -1,0 +1,1 @@
+This is a dummy license file.

--- a/legal/PTA_CHARTER.md
+++ b/legal/PTA_CHARTER.md
@@ -1,0 +1,19 @@
+# Parent Teacher Association Charter
+
+**Note:** This is a placeholder file.
+
+The official signed and adopted Charter of the [School Name] Parent Teacher Association should be inserted here.
+
+This document outlines the fundamental principles, structure, objectives, and operating procedures of the PTA. It typically includes:
+
+*   Name and Purpose of the Association
+*   Membership criteria and rights
+*   Officers and their duties
+*   Executive Board composition and responsibilities
+*   Committee structure
+*   Meeting schedules and quorum requirements
+*   Financial policies
+*   Amendment procedures
+*   Dissolution clause
+
+Please replace this placeholder text with the full content of the official PTA Charter.


### PR DESCRIPTION
This commit introduces a foundational set of documents and a directory structure for the Parent Teacher Association.

Key additions include:
- A `legal` directory for corporate documents.
- An updated main `README.md` to serve as an entry point, linking to key resources.
- `CODE_OF_CONDUCT.md` providing guidelines for community interaction.
- `PROCESSES.md` outlining common PTA procedures like joining, proposing initiatives, and decision-making.
- A placeholder `legal/PTA_CHARTER.md` for the official association charter.

These documents use placeholders like `[School Name]` which you will need to update with specific information.